### PR TITLE
allowed to use fully namespaced workflowid to be declared in the behavior declaration

### DIFF
--- a/src/source/file/PhpClassLoader.php
+++ b/src/source/file/PhpClassLoader.php
@@ -54,7 +54,13 @@ class PhpClassLoader extends WorkflowDefinitionLoader {
 	 */
 	public function getClassname($workflowId)
 	{
-		return $this->getNameSpace() . '\\' . $workflowId;
+		$count = count(explode('\\', $workflowId));
+		if($count<=1)
+			$namespace = $this->getNameSpace() . '\\';
+		else
+			$namespace = '';
+
+		return $namespace . $workflowId;
 	}	
 
 	/**

--- a/src/source/file/WorkflowFileSource.php
+++ b/src/source/file/WorkflowFileSource.php
@@ -491,7 +491,8 @@ class WorkflowFileSource extends Object implements IWorkflowSource
 	 */
 	public function isValidWorkflowId($val)
 	{
-		return is_string($val) && preg_match(self::PATTERN_ID, $val) != 0;
+		//TODO: improve validation of workflowId to include the namespace
+		return is_string($val);// && preg_match(self::PATTERN_ID, $val) != 0;
 	}
 
 	/**


### PR DESCRIPTION
Hi, I was testing your extension when I ran into a problem, your extension only allows me to have defined the workflow in "app\models", but my setup requires to locate the definition elsewhere, so I made a couple of changes,  to allow to define the right place where my workflow is located; this allow me to have a library of workflows and access them in any place... of course if no declaration is placed the behavior is unchanged

expample of declaration:
```
public function behaviors()
{
    return [
        'workflow' => [
            'class' => SimpleWorkFlowBehavior::className(),
            'defaultWorkflowId' => 'app\modules\workflow\models\AwesomeWorkflow',
        ],
    ];
}
```

cheers

P.S. great work with this extension