### PR TITLE
Differentiate null and 0 for status

### DIFF
--- a/src/base/StatusIdConverter.php
+++ b/src/base/StatusIdConverter.php
@@ -121,6 +121,6 @@ class StatusIdConverter extends Object implements IStatusIdConverter
 			throw new Exception('Conversion from SimpleWorkflow failed : no key found for id = '.$id);
 		}
 		$value = $this->_map[$id];
-		return ($value == self::VALUE_NULL ? null : $value);
+		return ($value === self::VALUE_NULL ? null : $value);
 	}
 }


### PR DESCRIPTION
If a initial status is 0, it will be set to null by this converter. It should be differentiated.